### PR TITLE
feat(ai): image upload support in AI methods

### DIFF
--- a/.changeset/image-upload-ai.md
+++ b/.changeset/image-upload-ai.md
@@ -1,0 +1,13 @@
+---
+"@boldvideo/bold-js": minor
+---
+
+Add image-upload support to `bold.ai` (chat / ask / coach / search)
+
+- New `images?: ImageInput[]` parameter on `ChatOptions` and `SearchOptions` — accepts `File`, `Blob`, or pre-encoded `{ type: 'base64', mediaType, data }` items. `ask` and `coach` inherit support via delegation to `chat`.
+- New helpers: `bold.ai.imageFromFile(file)`, `bold.ai.imageFromCanvas(canvas, options?)`, `bold.ai.validateImage(file, limits)`.
+- New `MultimodalCapability` type, exposed on `Account.multimodal?` from `GET /api/v1/settings`.
+- New `image_analysis` SSE event on the typed `AIEvent` union (`{ status: "analyzing" }` and `{ status: "complete", description }`).
+- New typed `AIAPIError` thrown on non-2xx responses from all AI HTTP paths (replaces generic `Error`).
+
+Wire format for images is snake_case (`{ type: 'base64', media_type, data }`); the SDK handles the rename transparently.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,12 +24,14 @@ export type {
   ThemeColors,
   Account,
   AccountAI,
+  MultimodalCapability,
   Segment,
   Source,
   Citation,
   AIUsage,
   AIEvent,
   AIResponse,
+  ImageInput,
   ChatOptions,
   SearchOptions,
   AIContextMessage,
@@ -77,3 +79,4 @@ export type {
 export type { ViewerLookupParams } from "./lib/viewers";
 export { ViewerAPIError } from "./lib/viewers";
 export { CommunityAPIError } from "./lib/community";
+export { AIAPIError } from "./lib/ai";

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,4 @@
-import type { AIEvent, AIResponse, ChatOptions, SearchOptions, RecommendationsOptions, RecommendationsResponse, AskOptions, RecommendOptions, RecommendResponse, Conversation } from './types';
+import type { AIEvent, AIResponse, ChatOptions, SearchOptions, RecommendationsOptions, RecommendationsResponse, AskOptions, RecommendOptions, RecommendResponse, Conversation, ImageInput, MultimodalCapability } from './types';
 import { camelizeKeys } from '../util/camelize';
 
 export interface AIConfig {
@@ -189,6 +189,140 @@ async function getRequest<T>(
 }
 
 /**
+ * Encode a Blob to a raw base64 string (no data URL prefix).
+ * Isomorphic: prefers FileReader.readAsDataURL when available, falls back to
+ * arrayBuffer() + btoa() for environments without FileReader (Node, Deno, edge).
+ */
+async function blobToBase64(blob: Blob): Promise<string> {
+  if (typeof FileReader !== 'undefined') {
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result !== 'string') {
+          reject(new Error('FileReader did not produce a string result'));
+          return;
+        }
+        const commaIdx = result.indexOf(',');
+        resolve(commaIdx >= 0 ? result.slice(commaIdx + 1) : result);
+      };
+      reader.onerror = () => reject(reader.error ?? new Error('FileReader error'));
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  // Avoid `String.fromCharCode(...bytes)` — splat blows up for large buffers.
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + CHUNK)) as number[],
+    );
+  }
+  if (typeof btoa === 'undefined') {
+    throw new Error('Cannot encode image: neither FileReader nor btoa is available');
+  }
+  return btoa(binary);
+}
+
+/**
+ * Normalize an ImageInput to the snake_case wire shape the server expects.
+ * Pre-encoded items are renamed in place; File/Blob are encoded via blobToBase64.
+ */
+async function encodeImageInput(
+  img: ImageInput,
+): Promise<{ type: 'base64'; media_type: string; data: string }> {
+  if (!(img instanceof Blob) && typeof img === 'object' && 'mediaType' in img) {
+    return { type: 'base64', media_type: img.mediaType, data: img.data };
+  }
+  // File | Blob
+  const blob = img as Blob;
+  const mediaType = blob.type || 'image/png';
+  const data = await blobToBase64(blob);
+  return { type: 'base64', media_type: mediaType, data };
+}
+
+/**
+ * Convert a File or Blob into an ImageInput ready to drop into `images: [...]`.
+ * Returns the camelCase shape (`mediaType`); the wire rename happens during
+ * request building.
+ */
+async function imageFromFile(file: File | Blob): Promise<ImageInput> {
+  const mediaType = file.type || 'image/png';
+  const data = await blobToBase64(file);
+  return { type: 'base64', mediaType, data };
+}
+
+type CanvasLike =
+  | HTMLCanvasElement
+  | OffscreenCanvas
+  | {
+      toBlob?: (cb: (b: Blob | null) => void, type?: string, quality?: number) => void;
+      convertToBlob?: (options?: { type?: string; quality?: number }) => Promise<Blob>;
+    };
+
+/**
+ * Convert a canvas (HTMLCanvasElement, OffscreenCanvas, or any object exposing
+ * toBlob / convertToBlob) to an ImageInput.
+ */
+async function imageFromCanvas(
+  canvas: CanvasLike,
+  options?: { type?: string; quality?: number },
+): Promise<ImageInput> {
+  const type = options?.type ?? 'image/png';
+  const quality = options?.quality;
+
+  const c = canvas as {
+    toBlob?: (cb: (b: Blob | null) => void, type?: string, quality?: number) => void;
+    convertToBlob?: (o?: { type?: string; quality?: number }) => Promise<Blob>;
+  };
+
+  let blob: Blob | null;
+  if (typeof c.convertToBlob === 'function') {
+    blob = await c.convertToBlob({ type, quality });
+  } else if (typeof c.toBlob === 'function') {
+    blob = await new Promise<Blob | null>((resolve) =>
+      c.toBlob!((b) => resolve(b), type, quality),
+    );
+  } else {
+    throw new TypeError(
+      'imageFromCanvas: canvas must expose toBlob() or convertToBlob()',
+    );
+  }
+
+  if (!blob) {
+    throw new Error('imageFromCanvas: canvas produced no blob');
+  }
+
+  return imageFromFile(blob);
+}
+
+/**
+ * Pure validator that checks a File/Blob against the multimodal capability
+ * limits the caller fetched from `bold.settings()`. Returns `{ valid: true }`
+ * when limits are missing, disabled, or do not constrain media types.
+ */
+function validateImage(
+  file: File | Blob,
+  limits: MultimodalCapability,
+): { valid: boolean; error?: string } {
+  if (!limits || limits.enabled === false) return { valid: true };
+  const accepted = limits.acceptedMediaTypes;
+  if (!accepted || accepted.length === 0) return { valid: true };
+  const mediaType = file.type || '';
+  if (!accepted.includes(mediaType)) {
+    return {
+      valid: false,
+      error: `Unsupported media type "${mediaType || '(unknown)'}". Accepted: ${accepted.join(', ')}`,
+    };
+  }
+  return { valid: true };
+}
+
+/**
  * AI client interface for type-safe method overloading
  */
 export interface AIClient {
@@ -281,6 +415,37 @@ export interface AIClient {
    * }
    */
   getConversation(conversationId: string): Promise<Conversation>;
+
+  /**
+   * Convert a File or Blob into a base64 ImageInput payload for use with
+   * `images: [...]` on chat / ask / coach / search.
+   */
+  imageFromFile(file: File | Blob): Promise<ImageInput>;
+
+  /**
+   * Convert an HTMLCanvasElement / OffscreenCanvas (or any object exposing
+   * toBlob / convertToBlob) into a base64 ImageInput payload.
+   */
+  imageFromCanvas(
+    canvas:
+      | HTMLCanvasElement
+      | OffscreenCanvas
+      | {
+          toBlob?: (cb: (b: Blob | null) => void, type?: string, quality?: number) => void;
+          convertToBlob?: (options?: { type?: string; quality?: number }) => Promise<Blob>;
+        },
+    options?: { type?: string; quality?: number },
+  ): Promise<ImageInput>;
+
+  /**
+   * Pure client-side validator. Pass the multimodal limits from
+   * `(await bold.settings()).data.account.multimodal`. Returns `{ valid: true }`
+   * when limits are missing or disabled.
+   */
+  validateImage(
+    file: File | Blob,
+    limits: MultimodalCapability,
+  ): { valid: boolean; error?: string };
 }
 
 /**
@@ -376,5 +541,8 @@ export function createAI(config: AIConfig): AIClient {
     recommendations: recommendations as AIClient['recommendations'],
     recommend: recommend as AIClient['recommend'],
     getConversation,
+    imageFromFile,
+    imageFromCanvas,
+    validateImage,
   };
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,6 +7,40 @@ export interface AIConfig {
 }
 
 /**
+ * Typed error thrown by AI HTTP failures (non-2xx responses or fetch errors).
+ * Mirrors ViewerAPIError / CommunityAPIError but adapted for fetch.
+ */
+export class AIAPIError extends Error {
+  readonly status?: number;
+  readonly originalError?: Error;
+
+  constructor(method: string, url: string, response?: Response, error?: unknown) {
+    let status: number | undefined;
+    let message: string;
+
+    if (response) {
+      status = response.status;
+      message = response.statusText || `HTTP ${response.status}`;
+    } else if (error instanceof Error) {
+      message = error.message;
+    } else if (error !== undefined) {
+      message = String(error);
+    } else {
+      message = 'unknown error';
+    }
+
+    super(
+      status !== undefined
+        ? `${method} ${url} failed (${status}): ${message}`
+        : `${method} ${url} failed: ${message}`,
+    );
+    this.name = 'AIAPIError';
+    this.status = status;
+    if (error instanceof Error) this.originalError = error;
+  }
+}
+
+/**
  * Parse SSE stream into typed events
  */
 async function* parseSSE(response: Response): AsyncIterable<AIEvent> {
@@ -95,7 +129,7 @@ async function streamRequest(
   });
 
   if (!response.ok) {
-    throw new Error(`AI request failed: ${response.status} ${response.statusText}`);
+    throw new AIAPIError('POST', url.toString(), response);
   }
 
   return parseSSE(response);
@@ -122,7 +156,7 @@ async function jsonRequest<T = AIResponse>(
   });
 
   if (!response.ok) {
-    throw new Error(`AI request failed: ${response.status} ${response.statusText}`);
+    throw new AIAPIError('POST', url.toString(), response);
   }
 
   const raw = await response.json();
@@ -147,7 +181,7 @@ async function getRequest<T>(
   });
 
   if (!response.ok) {
-    throw new Error(`AI request failed: ${response.status} ${response.statusText}`);
+    throw new AIAPIError('GET', url.toString(), response);
   }
 
   const raw = await response.json();

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -469,6 +469,9 @@ export function createAI(config: AIConfig): AIClient {
     if (isVideoScoped && options.currentTime !== undefined) {
       body.current_time = options.currentTime;
     }
+    if (options.images?.length) {
+      body.images = await Promise.all(options.images.map(encodeImageInput));
+    }
 
     if (options.stream === false) {
       body.stream = false;
@@ -495,6 +498,9 @@ export function createAI(config: AIConfig): AIClient {
     if (options.videoId) body.video_id = options.videoId;
     if (options.tags) body.tags = options.tags;
     if (options.context) body.context = options.context;
+    if (options.images?.length) {
+      body.images = await Promise.all(options.images.map(encodeImageInput));
+    }
 
     if (options.stream === false) {
       body.stream = false;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -347,6 +347,14 @@ export interface ChatOptions {
    * Helps AI understand what the viewer just watched.
    */
   currentTime?: number;
+
+  /**
+   * Optional image attachments. File/Blob items are auto-encoded to base64.
+   * Pre-encoded `{ type: 'base64', mediaType, data }` items are passed through.
+   * Server-side limits (count, media types) are exposed on
+   * `settings.account.multimodal`.
+   */
+  images?: ImageInput[];
 }
 
 /**
@@ -373,6 +381,9 @@ export interface SearchOptions {
   videoId?: string;
   tags?: string[];           // Filter by tags
   context?: AIContextMessage[];
+
+  /** Optional image attachments. See ChatOptions.images. */
+  images?: ImageInput[];
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,6 +183,16 @@ export type AccountAISearch = {
   enabled: boolean;
 };
 
+/**
+ * Multimodal (image upload) capability for the account. Server emits this on
+ * `account.multimodal`. Older API instances may omit it entirely.
+ */
+export type MultimodalCapability = {
+  enabled: boolean;
+  maxImages?: number;
+  acceptedMediaTypes?: string[];
+};
+
 export type PersonaEnabled = {
   enabled: true;
   name: string;
@@ -199,6 +209,7 @@ export type Persona = PersonaEnabled | PersonaDisabled;
 export type Account = {
   ai: AccountAI;
   aiSearch: AccountAISearch;
+  multimodal?: MultimodalCapability;
   name: string;
   persona: Persona;
   slug: string;
@@ -282,7 +293,21 @@ export type AIEvent =
   | { type: "text_delta"; delta: string }
   | { type: "recommendations"; recommendations: Recommendation[] }
   | { type: "message_complete"; conversationId?: string; content: string; citations: Segment[]; responseType: "answer" | "clarification"; usage?: AIUsage; context?: AIContextMessage[]; recommendations?: Recommendation[]; guidance?: string }
-  | { type: "error"; code: string; message: string; retryable: boolean };
+  | { type: "error"; code: string; message: string; retryable: boolean }
+  | { type: "image_analysis"; status: "analyzing" }
+  | { type: "image_analysis"; status: "complete"; description: string };
+
+/**
+ * Image attachment payload accepted by bold.ai.chat / ask / coach / search.
+ *
+ * - `File` and `Blob` are auto-encoded to base64 by the SDK.
+ * - The pre-encoded form lets callers cache encoded payloads or build them
+ *   from non-DOM sources.
+ */
+export type ImageInput =
+  | File
+  | Blob
+  | { type: 'base64'; mediaType: string; data: string };
 
 /**
  * Non-streaming AI response for /ai/chat, /ai/videos/:id/chat, and /ai/search


### PR DESCRIPTION
[BOLD-1449](https://linear.app/boldvideo/issue/BOLD-1449/sdk-boldvideobold-js-image-upload-support-in-ai-methods) | [Artifacts](https://cloud.codelayer.cloud/tasks/019de29d-26d0-7122-bef2-114c7fff98b3/artifacts) | [Deep link](https://cloud.codelayer.cloud/deep/tasks/019de29d-26d0-7122-bef2-114c7fff98b3)

## What problems was I solving

The Bold API now accepts image attachments on AI endpoints (chat, ask, coach, search) and exposes a multimodal capability flag in `GET /api/v1/settings` ([BOLD-1444](https://linear.app/boldvideo/issue/BOLD-1444/accept-images-array-in-ai-endpoint-request-body), [BOLD-1495](https://linear.app/boldvideo/issue/BOLD-1495/api-expose-multimodal-capability-in-apiv1settings)). Until this PR, callers using `@boldvideo/bold-js` had no typed way to pass images, no helper to convert a `File`/`Blob`/canvas into the wire format, and no surfaced `image_analysis` SSE event. They'd have to hand-roll base64 encoding and bypass the SDK's typed request layer.

After this ships:
- Portal/starter-kit consumers can wire up paperclip uploads, drag-and-drop, and paste-image flows by passing `images: [file]` to existing `bold.ai.chat` / `ask` / `coach` / `search` calls.
- The `image_analysis` streaming event is part of the typed `AIEvent` union, so UI code can render an "Analyzing…" indicator without `as any` casts.
- A typed `AIAPIError` replaces the previous generic `Error` for HTTP failures across all AI requests, making error handling consistent with `ViewerAPIError` / `CommunityAPIError`.

Success looks like: starter-kit (BOLD-1450 sibling work) can adopt the SDK's image-upload API directly without re-implementing base64 conversion or hand-typing the SSE event.

## What user-facing changes did I ship

- [src/lib/types.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5) — New `ImageInput` (File | Blob | pre-encoded base64) and `MultimodalCapability` types; `images?: ImageInput[]` added to `ChatOptions` and `SearchOptions`; `image_analysis` events added to the `AIEvent` discriminated union; `Account.multimodal?` field exposed.
- [src/lib/ai.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95) — New `bold.ai.imageFromFile`, `bold.ai.imageFromCanvas`, `bold.ai.validateImage` helpers; new `AIAPIError` class; `images` array auto-encoded to base64 and forwarded on chat/ask/coach/search request bodies.
- [src/index.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) — Re-exports `ImageInput`, `MultimodalCapability`, and `AIAPIError` from the package root.

## How I implemented it

Shipped in three commits that mirror the structure outline (types → helpers → wiring), so each step compiles independently and the diff stays reviewable.

### Phase 1 — Types & error class ([f1af091](https://github.com/boldvideo/bold-js/pull/51/commits/f1af091))
- [src/lib/types.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5) — Added `MultimodalCapability` (with optional `maxImages` / `acceptedMediaTypes` so older API instances that omit them still type-check), wired it onto `Account.multimodal?`, extended `AIEvent` with two `image_analysis` variants (`status: "analyzing"` and `status: "complete"` with `description`), and introduced the `ImageInput` union (`File | Blob | { type: 'base64'; mediaType: string; data: string }`).
- [src/lib/ai.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95) — Added the `AIAPIError` class and replaced all three `throw new Error('AI request failed: ...')` sites in `streamRequest`, `jsonRequest`, and `getRequest` with typed `AIAPIError` throws. Mirrors the shape of `ViewerAPIError` / `CommunityAPIError`.
- [src/index.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) — Re-exported the new types and error class.

### Phase 2 — Encoding helpers ([a533bf2](https://github.com/boldvideo/bold-js/pull/51/commits/a533bf2))
- [src/lib/ai.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95) — Added an isomorphic `blobToBase64` that prefers `FileReader.readAsDataURL` (browser) and falls back to `arrayBuffer()` + chunked `btoa` for Node/edge runtimes. The chunked encoding (`CHUNK = 0x8000`) avoids the `String.fromCharCode(...bytes)` argument-splat overflow that bites large images.
- Added `encodeImageInput` (normalizes `File`/`Blob`/pre-encoded objects to the snake_case wire shape `{ type: 'base64', media_type, data }`), the public `imageFromFile`, `imageFromCanvas` (handles both `HTMLCanvasElement.toBlob` and `OffscreenCanvas.convertToBlob`), and `validateImage` (pure validator against `MultimodalCapability` limits — gracefully no-ops when limits are missing or the capability is disabled). All three helpers are attached to the `createAI` return object so they're reachable as `bold.ai.imageFromFile(...)`.

### Phase 3 — Wire images into request bodies ([dfe7d5b](https://github.com/boldvideo/bold-js/pull/51/commits/dfe7d5b))
- [src/lib/ai.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95) — In `chat()` and `search()`, when `options.images?.length`, the array is `await Promise.all(options.images.map(encodeImageInput))` and dropped onto `body.images` before the `stream === false` branch. `ask()` and `coach()` are thin wrappers around `chat()`, so they inherit `images` support for free with no signature changes.
- [src/lib/types.ts](https://github.com/boldvideo/bold-js/pull/51/files#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5) — Added `images?: ImageInput[]` to `ChatOptions` and `SearchOptions`.

## Deviations from the plan

### Implemented as planned
- `MultimodalCapability` type, `Account.multimodal?` field, and `image_analysis` events on the `AIEvent` union.
- `ImageInput` union and `images?` on `ChatOptions` / `SearchOptions`.
- `AIAPIError` class shape and the three replacement sites in `streamRequest` / `jsonRequest` / `getRequest`.
- `blobToBase64` with FileReader-first / `btoa`-fallback and the `CHUNK = 0x8000` guard.
- `imageFromFile`, `imageFromCanvas` (with `convertToBlob` preferred over `toBlob`), and `validateImage` as module-scoped functions, attached to the `createAI` return object.
- `images` encoded via `Promise.all(...map(encodeImageInput))` in both `chat()` and `search()` before the `stream === false` branch; `ask` and `coach` inherit through delegation.
- Plan's explicit exclusions honored: no `url` field, no `images` on `recommendations`, no `maxBytes` validation, no top-level helper exports.

### Deviations/surprises
- **`encodeImageInput` type guard:** the plan specified `if (img && typeof img === 'object' && 'type' in img && img.type === 'base64')`. The implementation uses `if (!(img instanceof Blob) && typeof img === 'object' && 'mediaType' in img)`. Equivalent in practice — checks `mediaType` presence and excludes `Blob` via `instanceof` rather than asserting `type === 'base64'`. Slightly more robust against `Blob` subclasses that happen to expose a `type` property.

### Additions not in plan
- None. Diff is strictly additive relative to the plan.

### Items planned but not implemented
- None.

## How to verify it

### Setup
```bash
git fetch
git checkout humanlayer/bold-1449-sdk-boldvideobold-js-image-upload-support-in-ai-methods
pnpm install
pnpm run build
pnpm run lint
```

### Manual Testing
- [ ] In a consumer app, call `bold.ai.imageFromFile(file)` with a small PNG and confirm the resolved object has `{ type: 'base64', mediaType: 'image/png', data: '<base64>' }`.
- [ ] Call `bold.ai.chat({ prompt: 'describe this', images: [file] })` against a tenant with multimodal enabled; confirm the request body contains `images: [{ type: 'base64', media_type, data }]` (snake_case on the wire).
- [ ] Confirm `ask()` and `coach()` accept `images` (they should — both delegate to `chat`).
- [ ] Trigger a streamed response that emits `image_analysis` events and verify the `.on('image_analysis', ...)` handler receives both `{ status: 'analyzing' }` and `{ status: 'complete', description }` payloads with full type narrowing.
- [ ] Force a non-2xx response from any AI endpoint and confirm the thrown error is an instance of `AIAPIError` with a numeric `status`.
- [ ] Call `bold.ai.validateImage(file, settings.account.multimodal)` with a media type outside `acceptedMediaTypes` and confirm `{ valid: false, error: '...' }`; with limits absent, confirm `{ valid: true }`.

### Automated Tests
```bash
pnpm run lint
pnpm run build
```
(No unit-test framework is configured in this repo.)

## Description for the changelog

`bold.ai` now accepts `images: [File | Blob | base64]` on chat/ask/coach/search, exposes `imageFromFile` / `imageFromCanvas` / `validateImage` helpers, surfaces the `image_analysis` SSE event, and throws a typed `AIAPIError` on HTTP failures.
