### PR TITLE
feat(community): align API types to camelCase runtime + nested comment reactions

### DIFF
--- a/.changeset/community-camelcase-types.md
+++ b/.changeset/community-camelcase-types.md
@@ -12,5 +12,6 @@ The SDK camelizes every API response at the transport boundary, but since 1.19.0
 - `CommentSummary.commented_by` → `commentedBy`
 - `Reply.created_at` / `parent_comment_id` → `createdAt` / `parentCommentId`
 - `CommentThread.created_at` → `createdAt`
+- `PaginationMeta.page_size` / `total_entries` / `total_pages` → `pageSize` / `totalEntries` / `totalPages`
 
 Comments and replies now expose nested reaction state via a new `CommentReactionSummary` type (`{ count, viewerHasReacted? }`): `CommentThread.reactions` and `Reply.reactions`.

--- a/.changeset/community-camelcase-types.md
+++ b/.changeset/community-camelcase-types.md
@@ -1,0 +1,16 @@
+---
+"@boldvideo/bold-js": minor
+---
+
+Fix community API types to match the camelCase runtime (BOLD-1577) and add nested comment reactions (BOLD-1580)
+
+The SDK camelizes every API response at the transport boundary, but since 1.19.0 the community types declared snake_case fields as canonical, so those fields were `undefined` at runtime (e.g. `post.created_at`). All community read types now declare camelCase fields, matching what the SDK actually returns:
+
+- `Post.created_at` → `createdAt` (the always-undefined snake_case field is removed)
+- `UserSummary.avatar_url` → `avatarUrl`
+- `ReactionSummary.reacted_by` / `viewer_has_reacted` → `reactedBy` / `viewerHasReacted`
+- `CommentSummary.commented_by` → `commentedBy`
+- `Reply.created_at` / `parent_comment_id` → `createdAt` / `parentCommentId`
+- `CommentThread.created_at` → `createdAt`
+
+Comments and replies now expose nested reaction state via a new `CommentReactionSummary` type (`{ count, viewerHasReacted? }`): `CommentThread.reactions` and `Reply.reactions`.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ await bold.community.comments.delete('viewer-uuid', 'comment-id');
 
 // React to a comment (toggle)
 const reaction = await bold.community.comments.react('viewer-uuid', 'comment-id');
+
+// Read nested reaction state on comments/replies (viewerId enables viewerHasReacted)
+const { data: post } = await bold.community.posts.get('post-id', 'viewer-uuid');
+for (const thread of post.comments.items ?? []) {
+  console.log(thread.createdAt, thread.reactions.count, thread.reactions.viewerHasReacted);
+}
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -134,13 +134,20 @@ Build community features with posts, comments, and reactions. Write operations r
 // Example: List posts with pagination
 const response = await bold.community.posts.list({ page: 1, pageSize: 20, viewerId });
 // response.data = Post[]
-// response.meta = { page, page_size, total_entries, total_pages }
+// response.meta = { page, pageSize, totalEntries, totalPages }
 
 // Access users who reacted/commented (for avatar display)
 const post = response.data[0];
-post.reactions.reacted_by;      // UserSummary[] (up to 10)
-post.comments.commented_by;     // UserSummary[] (up to 10)
-post.reactions.viewer_has_reacted; // boolean (when viewerId provided)
+post.reactions.reactedBy;       // UserSummary[] (up to 10)
+post.comments.commentedBy;      // UserSummary[] (up to 10)
+post.reactions.viewerHasReacted; // boolean (when viewerId provided)
+
+// Read nested reaction state on comments/replies (detail view)
+const detail = await bold.community.posts.get(post.id, viewerId);
+for (const thread of detail.data.comments.items ?? []) {
+  thread.reactions.count;            // number
+  thread.reactions.viewerHasReacted; // boolean (when viewerId provided)
+}
 
 // Create and interact
 await bold.community.posts.create(viewerId, { content: 'Hello!', category: 'general' });
@@ -319,7 +326,7 @@ type AIEvent =
 {
   id: string;
   name: string;
-  avatar_url: string | null;
+  avatarUrl: string | null;
 }
 ```
 
@@ -329,10 +336,10 @@ type AIEvent =
 {
   id: string;
   content: string;             // Markdown content
-  created_at: string;
+  createdAt: string;
   author: PostAuthor;          // Creator of the post
-  reactions: ReactionSummary;  // { count, reacted_by, viewer_has_reacted? }
-  comments: CommentSummary;    // { count, commented_by, items? }
+  reactions: ReactionSummary;  // { count, reactedBy, viewerHasReacted? }
+  comments: CommentSummary;    // { count, commentedBy, items? }
   category?: string;
   pinned?: boolean;
   pinnedAt?: string | null;
@@ -345,8 +352,8 @@ type AIEvent =
 ```typescript
 {
   count: number;
-  reacted_by: UserSummary[];       // Capped to 10 from API
-  viewer_has_reacted?: boolean;    // Present when viewerId provided
+  reactedBy: UserSummary[];        // Capped to 10 from API
+  viewerHasReacted?: boolean;      // Present when viewerId provided
 }
 ```
 
@@ -355,7 +362,7 @@ type AIEvent =
 ```typescript
 {
   count: number;
-  commented_by: UserSummary[];     // Capped to 10 from API
+  commentedBy: UserSummary[];      // Capped to 10 from API
   items?: CommentThread[];         // Full threads (detail view only)
 }
 ```
@@ -366,9 +373,10 @@ type AIEvent =
 {
   id: string;
   content: string;
-  created_at: string;
+  createdAt: string;
   author: UserSummary;
   replies: Reply[];                // Nested replies
+  reactions: CommentReactionSummary;
 }
 ```
 
@@ -378,9 +386,19 @@ type AIEvent =
 {
   id: string;
   content: string;
-  created_at: string;
+  createdAt: string;
   author: UserSummary;
-  parent_comment_id: string;
+  parentCommentId: string;
+  reactions: CommentReactionSummary;
+}
+```
+
+### CommentReactionSummary
+
+```typescript
+{
+  count: number;
+  viewerHasReacted?: boolean;      // Present when viewerId provided
 }
 ```
 
@@ -391,16 +409,16 @@ type AIEvent =
   data: T[];
   meta: {
     page: number;              // Current page (1-indexed)
-    page_size: number;
-    total_entries: number;
-    total_pages: number;
+    pageSize: number;
+    totalEntries: number;
+    totalPages: number;
   };
 }
 ```
 
 ### Other types exported
 
-`Playlist`, `Settings`, `Portal`, `MenuItem`, `AIResponse`, `AIUsage`, `AIContextMessage`, `Conversation`, `ConversationMessage`, `RecommendationsResponse`, `Viewer`, `ViewerProgress`, `ViewerLookupParams`, `ListProgressOptions`, `ListVideosOptions`, `ListVideosLatestOptions`, `ListVideosIndexOptions`, `Post`, `PostAuthor`, `UserSummary`, `ReactionSummary`, `CommentSummary`, `CommentThread`, `Reply`, `Comment`, `ReactionResponse`, `ListPostsOptions`, `CreatePostData`, `UpdatePostData`, `CreateCommentData`, `PaginationMeta`, `PaginatedResponse`, `CommunityAPIError`
+`Playlist`, `Settings`, `Portal`, `MenuItem`, `AIResponse`, `AIUsage`, `AIContextMessage`, `Conversation`, `ConversationMessage`, `RecommendationsResponse`, `Viewer`, `ViewerProgress`, `ViewerLookupParams`, `ListProgressOptions`, `ListVideosOptions`, `ListVideosLatestOptions`, `ListVideosIndexOptions`, `Post`, `PostAuthor`, `UserSummary`, `ReactionSummary`, `CommentSummary`, `CommentReactionSummary`, `CommentThread`, `Reply`, `Comment`, `ReactionResponse`, `ListPostsOptions`, `CreatePostData`, `UpdatePostData`, `CreateCommentData`, `PaginationMeta`, `PaginatedResponse`, `CommunityAPIError`
 
 ## Error Handling
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export type {
   UserSummary,
   ReactionSummary,
   CommentSummary,
+  CommentReactionSummary,
   CommentThread,
   Reply,
   Comment,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -587,7 +587,7 @@ export type ListVideosOptions =
 export type UserSummary = {
   id: string;
   name: string;
-  avatar_url: string | null;
+  avatarUrl: string | null;
 };
 
 /**
@@ -604,9 +604,19 @@ export type PostAuthor = UserSummary & {
 export type ReactionSummary = {
   count: number;
   /** Users who reacted (capped to 10 from API) */
-  reacted_by: UserSummary[];
+  reactedBy: UserSummary[];
   /** Present when viewer context exists */
-  viewer_has_reacted?: boolean;
+  viewerHasReacted?: boolean;
+};
+
+/**
+ * Per-comment reaction state.
+ * Comments do not return a `reactedBy` list (unlike post reactions).
+ */
+export type CommentReactionSummary = {
+  count: number;
+  /** Present when viewer context (X-Viewer-ID) exists */
+  viewerHasReacted?: boolean;
 };
 
 /**
@@ -615,7 +625,7 @@ export type ReactionSummary = {
 export type CommentSummary = {
   count: number;
   /** Users who commented (capped to 10 from API) */
-  commented_by: UserSummary[];
+  commentedBy: UserSummary[];
   /** Full comment threads (present in detail only) */
   items?: CommentThread[];
 };
@@ -626,9 +636,10 @@ export type CommentSummary = {
 export type Reply = {
   id: string;
   content: string;
-  created_at: string;
+  createdAt: string;
   author: UserSummary;
-  parent_comment_id: string;
+  parentCommentId: string;
+  reactions: CommentReactionSummary;
 };
 
 /**
@@ -637,9 +648,10 @@ export type Reply = {
 export type CommentThread = {
   id: string;
   content: string;
-  created_at: string;
+  createdAt: string;
   author: UserSummary;
   replies: Reply[];
+  reactions: CommentReactionSummary;
 };
 
 /**
@@ -672,21 +684,19 @@ export type Post = {
   category?: string;
   pinned?: boolean;
   pinnedAt?: string | null;
-  created_at: string;
+  createdAt: string;
+  updatedAt?: string;
   author: PostAuthor;
   reactions: ReactionSummary;
   comments: CommentSummary;
-  /** @deprecated Use created_at */
-  createdAt?: string;
   /** @deprecated Use reactions.count */
   reactionsCount?: number;
   /** @deprecated Use comments.count */
   commentsCount?: number;
-  /** @deprecated Use reactions.viewer_has_reacted */
+  /** @deprecated Use reactions.viewerHasReacted */
   viewerReacted?: boolean;
   /** @deprecated Use author */
   viewer?: PostAuthor;
-  updatedAt?: string;
 };
 
 /**
@@ -729,7 +739,7 @@ export type ListPostsOptions = {
   page?: number;
   /** Items per page (default: 20, max: 100) */
   pageSize?: number;
-  /** Viewer ID to include viewer_has_reacted in response */
+  /** Viewer ID to include viewerHasReacted in response */
   viewerId?: string;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -714,11 +714,11 @@ export type PaginationMeta = {
   /** Current page (1-indexed) */
   page: number;
   /** Items per page */
-  page_size: number;
+  pageSize: number;
   /** Total items across all pages */
-  total_entries: number;
+  totalEntries: number;
   /** Total number of pages */
-  total_pages: number;
+  totalPages: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

Types-only change that fixes a type/runtime inversion in the community API and adds nested comment reactions. The runtime transformer (`camelizeKeys`) already produces camelCase keys — this aligns the type declarations to match.

Since v1.19.0 the community types declared **snake_case** fields as canonical (`created_at`, `reacted_by`, `viewer_has_reacted`, `commented_by`, `parent_comment_id`, `avatar_url`), but the SDK camelizes every response at the transport boundary. The result: the declared canonical fields were `undefined` at runtime (e.g. `post.created_at`), while the data lived under camelCase keys that were `@deprecated` or untyped. `tsc` couldn't catch this because `camelizeKeys<T>(input: T): T` is typed as an identity and call sites cast with `as T`.

## Changes

**BOLD-1577 — re-case community read types** (`src/lib/types.ts`)
- `Post.created_at` → `createdAt` (always-undefined snake_case field **removed**)
- `UserSummary.avatar_url` → `avatarUrl`
- `ReactionSummary.reacted_by` / `viewer_has_reacted` → `reactedBy` / `viewerHasReacted`
- `CommentSummary.commented_by` → `commentedBy`
- `Reply.created_at` / `parent_comment_id` → `createdAt` / `parentCommentId`
- `CommentThread.created_at` → `createdAt`
- Nested-data `@deprecated` aliases on `Post` (`reactionsCount`, `commentsCount`, `viewerReacted`, `viewer`) kept as-is; JSDoc references updated to camelCase.

**BOLD-1580 — nested comment reactions** (`src/lib/types.ts`, `src/index.ts`)
- New `CommentReactionSummary` type (`{ count, viewerHasReacted? }`) — exported from the package
- `reactions: CommentReactionSummary` added to `CommentThread` and `Reply` (matches backend PR #377; no `reactedBy` list on comment reactions)

**Docs + changeset**
- README snippet for reading nested comment reactions
- `minor` changeset (matches the v1.19.0 community-redesign precedent)

## Verification

- ✅ `pnpm run lint` (tsc)
- ✅ `pnpm run build` (tsup) — declarations emit, `CommentReactionSummary` present in `dist/index.d.ts`
- ✅ No snake_case keys remain in the community type block
- ✅ `pnpm changeset status` → queued for minor bump

**Manual (not yet run — needs a live/staged channel):** verify `post.createdAt`, `post.author.avatarUrl`, `post.reactions.reactedBy`/`viewerHasReacted`, `comments.items[].createdAt`/`reactions`, and `replies[].parentCommentId`/`reactions` are populated against a real response with a `viewerId`.

## Migration / breaking-ness

Renaming/removing the snake_case fields is source-breaking for consumers that reference those names — but every such reference is **already broken at runtime** (those fields are always `undefined`), so this is effectively a bug fix. Shipped as a **minor** bump per the v1.19.0 precedent. Consumers can drop any `?? created_at`-style fallbacks (e.g. the temporary workaround in `bold-course-starter`) after upgrading.

## Out of scope (follow-ups)

- Properly type-mapping `camelizeKeys` snake→camel (the latent reason this drift was invisible to `tsc`) — separate ticket
- Stale README pagination example (`limit`/`offset`/`viewerReacted` pre-dates the 1.19.0 page/pageSize change) — separate docs cleanup

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784286634&installation_id=135138357&pr_number=53&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F53&signature=34a63196f2a67ab2f015858ffcf10e58a94ace2c305b6824b38d1100dc0a62f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->