### PR TITLE
ci: fix npm publish via trusted publishing (npm >= 11.5.1)

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -33,7 +33,11 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
-      
+
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -50,5 +54,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NODE_AUTH_TOKEN: publish authenticates via npm trusted publishing (OIDC).
+          # A stale/expired token here would shadow OIDC and fail the publish.
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Problem

The `1.21.0` release bumped the version on `main` correctly, but the `pnpm changeset publish` step **failed with E404**, so `1.21.0` was never published to npm (registry still serves `1.20.0`).

Root cause from the failed run log:
```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
npm notice publish Signed provenance statement ...
error ... E404 Not Found - PUT https://registry.npmjs.org/@boldvideo%2fbold-js
```

npm **signed provenance** (supported since npm 9.5) but the registry `PUT` was **unauthenticated** → 404. The reason: **npm trusted publishing (OIDC token exchange) requires npm ≥ 11.5.1**, but the workflow runs on **Node 20.x, which ships npm 10.x**. So the publish never actually authenticated. The trusted-publisher config on npmjs.com was correct all along.

## Fix

- **Upgrade npm to latest (≥ 11.5.1)** after `setup-node`, so the OIDC trusted-publishing exchange works.
- **Drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`** — the Feb-5 token is expired, and a stale token in `.npmrc` would shadow OIDC and re-break the publish. Trusted publishing is token-less; `id-token: write` + `NPM_CONFIG_PROVENANCE: true` remain.

## Effect on merge

`main` has **no pending changesets** and is already at `1.21.0`, so merging this triggers `changeset-release.yml` in **publish mode** — it will publish `@boldvideo/bold-js@1.21.0` with provenance, tag `v1.21.0`, and create the GitHub release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784288940&installation_id=135138357&pr_number=54&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F54&signature=50334baec0f3d1284b3f25b1835b244d0dcb094883542ef4207c81e9eebcfc89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->