### PR TITLE
chore(deps): bump typescript to ^6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "tsup": "^8.5.1",
-    "typescript": "^4.9.5"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "axios": "^1.18.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,10 +17,10 @@ importers:
         version: 2.31.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(typescript@4.9.5)
+        version: 8.5.1(typescript@6.0.3)
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -1061,9 +1061,9 @@ packages:
       typescript:
         optional: true
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.4:
@@ -2046,7 +2046,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(typescript@4.9.5):
+  tsup@8.5.1(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2066,14 +2066,14 @@ snapshots:
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  typescript@4.9.5: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { createClient } from "lib/client";
-export type { ClientOptions } from "lib/client";
+export { createClient } from "./lib/client";
+export type { ClientOptions } from "./lib/client";
 export { DEFAULT_API_BASE_URL, DEFAULT_INTERNAL_API_BASE_URL } from "./lib/constants";
 export type {
   Video,

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from "axios";
-import { throttle } from "util/throttle";
+import { throttle } from "../util/throttle";
 
 type ApiClient = AxiosInstance;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,10 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
-    "baseUrl": "src",
-    "declaration": true
+    "declaration": true,
+    // tsup's dts builder injects `baseUrl`, which TS 6 deprecates (TS5101).
+    // This silences it until tsup drops the injection / we move to TS 7.
+    // Our own config sets no baseUrl (imports are relative).
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
## Summary

Upgrades TypeScript **4.9.5 → 6.0.3** (the last toolchain dep left after #55). No consumer-facing change — `typescript` is a devDependency and the bundled output is unchanged, so **no changeset / no version bump**.

## What TS 6 required

TS 6.0 turns the deprecated **`baseUrl`** option into an error (TS5101 — removed entirely in TS 7). The project used `baseUrl: "src"` for a few non-relative imports. Rather than silence it blindly, I migrated off it:

- Relativized the **3** `baseUrl`-dependent imports (`src/index.ts` ×2 → `./lib/client`, `src/lib/tracking.ts` → `../util/throttle`).
- Removed `baseUrl` from `tsconfig.json`.
- Added `"ignoreDeprecations": "6.0"` — **required because tsup's own dts builder hardcodes `baseUrl` injection** (`tsup/dist/rollup.js`: `baseUrl: compilerOptions.baseUrl || "."`). Our own config sets no baseUrl; this only covers tsup's injection until tsup drops it / we move to TS 7. Also surfaced TS 6's new `--ignoreConfig`/TS5112 behavior during testing (handled in the smoke test, not the build).

## Testing (properly)

- ✅ `pnpm run lint` (tsc 6.0.3) clean
- ✅ `pnpm run build` — emits ESM (`index.js`), CJS (`index.cjs`), declarations (`index.d.ts` + `index.d.cts`)
- ✅ **Consumer smoke test** against the built `dist/` under TS 6 strict: `createClient` + all changed community types (`Post.createdAt`, `reactedBy`, `viewerHasReacted`, `commentedBy`, `CommentReactionSummary`, `PaginationMeta.pageSize`) resolve; a `@ts-expect-error` confirms `Post.created_at` is gone; `ImageInput` (1.21.x) resolves.
- ✅ Runtime load of both ESM and CJS builds — correct client shape (`community`, `videos`, `viewers`, `ai`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784289925&installation_id=135138357&pr_number=57&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F57&signature=9e6e04f4a0068ee4a13afdd037a8832b5104814e8a77c919879a0ad96d5c679f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->