### PR TITLE
chore: changeset for TS 6 toolchain (release 1.21.2)

### DIFF
--- a/.changeset/typescript-6-toolchain.md
+++ b/.changeset/typescript-6-toolchain.md
@@ -1,0 +1,5 @@
+---
+"@boldvideo/bold-js": patch
+---
+
+Internal toolchain modernization: upgrade TypeScript to 6.0 and migrate off the deprecated `baseUrl` compiler option (internal imports are now relative). No changes to the published API, types, or runtime behavior.


### PR DESCRIPTION
Adds a patch changeset for the internal TypeScript 6.0 / build-toolchain modernization merged in #57. No consumer-facing change — same published API, types, and runtime; the changeset cuts `1.21.2` to record the toolchain update as a version.

Merging this opens the Release PR for 1.21.2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784290542&installation_id=135138357&pr_number=58&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F58&signature=7cd7866bb2be925af22ea86896b29e70c5b2928b487cca43283e447eb7672a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->