### PR TITLE
feat: add session-management SDK helpers

### DIFF
--- a/.changeset/tame-rivers-watch.md
+++ b/.changeset/tame-rivers-watch.md
@@ -1,0 +1,5 @@
+---
+"@boldvideo/bold-js": minor
+---
+
+Add browser-safe auth session methods and server-side session-management helpers for password-sharing prevention.

--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,8 @@ tsconfig.json
 .github
 
 # Documentation (except README.md which should be included)
+AGENTS.md
 CLAUDE.md
 CONTRIBUTING.md
 SECURITY.md
+docs

--- a/README.md
+++ b/README.md
@@ -178,6 +178,94 @@ console.log(`Completed ${meta.completed} of ${meta.total} videos`);
 
 ---
 
+## Session Management
+
+Use BOLD Session Management as a headless password-sharing prevention layer.
+Your app still owns login, membership, product access, and staff/admin checks.
+Call BOLD only after your app has decided the viewer may access protected
+content.
+
+### Runtime Sessions
+
+Runtime session calls use the customer's upstream JWT, not a BOLD API key. This
+factory is safe for browser/native runtime code when the upstream JWT is already
+available to that runtime.
+
+```typescript
+import { createAuthClient } from '@boldvideo/bold-js';
+
+const auth = createAuthClient({
+  tenantSlug: 'hrtu',
+  upstreamJwt: outsetaJwt
+});
+
+const result = await auth.sessions.create({
+  deviceId: browserDeviceId,
+  platform: 'web',
+  userAgent: navigator.userAgent
+});
+
+let sessionId: string | undefined;
+
+if ('challengeRequired' in result) {
+  // Show an email-code challenge UI, then verify the code.
+  const verified = await auth.challenges.verify(result.challengeId, '123456');
+  sessionId = verified.sessionId ?? undefined;
+} else if (result.sessionId) {
+  sessionId = result.sessionId;
+}
+
+if (sessionId) {
+  localStorage.setItem('bold_session_id', sessionId);
+}
+
+if (sessionId) {
+  const verification = await auth.sessions.verify(sessionId);
+  if (!verification.valid) {
+    // session_not_found, session_revoked, or session_expired
+  }
+}
+```
+
+For refreshed JWTs, pass an override per call:
+
+```typescript
+await auth.sessions.verify(sessionId, { upstreamJwt: freshJwt });
+```
+
+Viewer self-management methods require policy support:
+
+```typescript
+const { data: sessions } = await auth.sessions.list();
+await auth.sessions.revoke(sessionId);
+await auth.sessions.revokeOthers(currentSessionId);
+```
+
+### Server-Side Session Management
+
+Customer servers can inspect and revoke BOLD device sessions by upstream
+external ID using the normal BOLD tenant API key. Keep this API key server-side.
+Do not put a BOLD tenant key or admin key in browser code.
+
+```typescript
+import { createClient } from '@boldvideo/bold-js';
+
+const bold = createClient(process.env.BOLD_TENANT_API_KEY!);
+
+const { data: sessions } =
+  await bold.sessionManagement.listViewerSessionsByExternalId(outsetaPersonUid);
+
+await bold.sessionManagement.revokeAllViewerSessionsByExternalId(
+  outsetaPersonUid,
+  { reason: 'outseta:membership_changed' }
+);
+```
+
+The server-side session-management methods cannot update policy, JWT config,
+feature flags, viewer device-limit overrides, or exemptions.
+
+---
+
 ## Community API
 
 Build community features with posts, comments, and reactions. All write operations require a `viewerId` (the viewer performing the action).

--- a/llms.txt
+++ b/llms.txt
@@ -111,6 +111,73 @@ const { data: progress, meta } = await bold.viewers.listProgress(viewer.id, { co
 console.log(`Completed ${meta.completed} of ${meta.total} videos`);
 ```
 
+## Session Management
+
+Session Management is BOLD's headless password-sharing prevention layer.
+Customer apps still own login, membership, product access, and staff/admin
+decisions. Call BOLD session enforcement only after your app has allowed the
+viewer to access protected content.
+
+### Runtime Auth Client
+
+Use `createAuthClient()` for browser/native/runtime session calls. It uses the
+customer's upstream JWT and tenant slug, not a BOLD API key.
+
+```typescript
+import { createAuthClient } from '@boldvideo/bold-js';
+
+const auth = createAuthClient({
+  tenantSlug: 'hrtu',
+  upstreamJwt: outsetaJwt
+});
+
+const result = await auth.sessions.create({
+  deviceId: deviceId,
+  platform: 'web',
+  userAgent: navigator.userAgent
+});
+
+if ('challengeRequired' in result) {
+  await auth.challenges.verify(result.challengeId, code);
+}
+
+const status = await auth.sessions.verify(sessionId, { upstreamJwt: freshJwt });
+const { data: activeSessions } = await auth.sessions.list();
+await auth.sessions.revoke(sessionId);
+await auth.sessions.revokeOthers(currentSessionId);
+```
+
+### Server-Side Tenant API Key Methods
+
+Use `createClient(BOLD_TENANT_API_KEY).sessionManagement` only on a customer
+server. Keep the normal BOLD tenant API key server-side. Never put
+`X-Bold-Admin-Api-Key` in a customer app.
+
+```typescript
+const bold = createClient(process.env.BOLD_TENANT_API_KEY!);
+
+const { data: viewer } =
+  await bold.sessionManagement.resolveViewerByExternalId(outsetaPersonUid);
+
+const { data: sessions } =
+  await bold.sessionManagement.listViewerSessionsByExternalId(outsetaPersonUid);
+
+await bold.sessionManagement.revokeViewerSessionByExternalId(
+  outsetaPersonUid,
+  sessionId,
+  { reason: 'support_request' }
+);
+
+await bold.sessionManagement.revokeAllViewerSessionsByExternalId(
+  outsetaPersonUid,
+  { reason: 'outseta:membership_changed' }
+);
+```
+
+Server-side session-management methods can inspect and revoke sessions by
+upstream external ID. They cannot update policy, JWT config, feature flags,
+viewer device-limit overrides, or exemptions.
+
 ## Community API
 
 Build community features with posts, comments, and reactions. Write operations require `viewerId`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { createClient } from "./lib/client";
 export type { ClientOptions } from "./lib/client";
+export { createAuthClient } from "./lib/auth";
+export type { AuthClientOptions, AuthRequestOptions } from "./lib/auth";
 export { DEFAULT_API_BASE_URL, DEFAULT_INTERNAL_API_BASE_URL } from "./lib/constants";
 export type {
   Video,
@@ -54,6 +56,24 @@ export type {
   UpdateViewerData,
   SaveProgressData,
   ProgressListMeta,
+  // Session Management API
+  AuthSessionPlatform,
+  AuthSessionCreateData,
+  AuthActiveSession,
+  AuthSessionCreatedResponse,
+  AuthSessionBypassedResponse,
+  AuthSessionChallengeResponse,
+  AuthSessionCreateResponse,
+  AuthSessionListResponse,
+  AuthSessionVerifyResponse,
+  AuthSessionRevokeResponse,
+  AuthSessionRevokeOthersResponse,
+  AuthChallengeResendResponse,
+  SessionManagementViewerResolveResponse,
+  SessionManagementSession,
+  SessionManagementViewerSessionsResponse,
+  SessionManagementRevokeSessionResponse,
+  SessionManagementRevokeAllResponse,
   // Video list options
   ListVideosOptions,
   ListVideosLatestOptions,
@@ -79,5 +99,8 @@ export type {
 
 export type { ViewerLookupParams } from "./lib/viewers";
 export { ViewerAPIError } from "./lib/viewers";
+export type { SessionManagementRevokeOptions } from "./lib/session-management";
+export { SessionManagementAPIError } from "./lib/session-management";
+export { AuthAPIError } from "./lib/auth";
 export { CommunityAPIError } from "./lib/community";
 export { AIAPIError } from "./lib/ai";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,7 +22,7 @@ const CONTROLLED_AUTH_HEADERS = new Set([
 export type AuthClientOptions = {
   baseURL?: string;
   tenantSlug: string;
-  upstreamJwt?: string;
+  upstreamJwt: string;
   headers?: AuthHeaders;
 };
 
@@ -66,7 +66,7 @@ function requireValue(value: string | undefined, message: string): string {
 }
 
 function bearer(value: string): string {
-  return value.startsWith("Bearer ") ? value : `Bearer ${value}`;
+  return /^bearer\s+/i.test(value) ? value : `Bearer ${value}`;
 }
 
 function customHeaders(...sources: Array<AuthHeaders | undefined>): AuthHeaders {
@@ -140,13 +140,17 @@ async function post<T>(
 
 export function createAuthClient(options: AuthClientOptions) {
   const tenantSlug = requireValue(options.tenantSlug, "Tenant slug is required");
+  const upstreamJwt = requireValue(
+    options.upstreamJwt,
+    "Upstream JWT is required"
+  );
   const client = axios.create({
     baseURL: options.baseURL ?? DEFAULT_API_BASE_URL,
   });
 
   const config: AuthClientConfig = {
     tenantSlug,
-    upstreamJwt: options.upstreamJwt,
+    upstreamJwt,
     headers: options.headers ?? {},
   };
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,230 @@
+import axios, { AxiosError, AxiosInstance } from "axios";
+
+import { camelizeKeys } from "../util/camelize";
+import { DEFAULT_API_BASE_URL } from "./constants";
+import type {
+  AuthChallengeResendResponse,
+  AuthSessionCreateData,
+  AuthSessionCreateResponse,
+  AuthSessionListResponse,
+  AuthSessionRevokeResponse,
+  AuthSessionRevokeOthersResponse,
+  AuthSessionVerifyResponse,
+} from "./types";
+
+type AuthHeaders = Record<string, string>;
+const CONTROLLED_AUTH_HEADERS = new Set([
+  "authorization",
+  "x-bold-tenant-slug",
+  "x-bold-session-id",
+]);
+
+export type AuthClientOptions = {
+  baseURL?: string;
+  tenantSlug: string;
+  upstreamJwt?: string;
+  headers?: AuthHeaders;
+};
+
+export type AuthRequestOptions = {
+  tenantSlug?: string;
+  upstreamJwt?: string;
+  headers?: AuthHeaders;
+};
+
+type AuthClientConfig = Required<Pick<AuthClientOptions, "tenantSlug">> &
+  Pick<AuthClientOptions, "upstreamJwt" | "headers">;
+
+export class AuthAPIError extends Error {
+  readonly status?: number;
+  readonly originalError?: Error;
+
+  constructor(method: string, url: string, error: unknown) {
+    if (error instanceof AxiosError) {
+      const status = error.response?.status;
+      const message =
+        error.response?.data?.error ||
+        error.response?.data?.message ||
+        error.response?.data?.code ||
+        error.message;
+      super(`${method} ${url} failed (${status}): ${message}`);
+      this.status = status;
+      this.originalError = error;
+    } else if (error instanceof Error) {
+      super(`${method} ${url} failed: ${error.message}`);
+      this.originalError = error;
+    } else {
+      super(`${method} ${url} failed: ${String(error)}`);
+    }
+    this.name = "AuthAPIError";
+  }
+}
+
+function requireValue(value: string | undefined, message: string): string {
+  if (!value || typeof value !== "string") throw new Error(message);
+  return value;
+}
+
+function bearer(value: string): string {
+  return value.startsWith("Bearer ") ? value : `Bearer ${value}`;
+}
+
+function customHeaders(...sources: Array<AuthHeaders | undefined>): AuthHeaders {
+  return sources.reduce<AuthHeaders>((headers, source) => {
+    if (!source) return headers;
+
+    for (const [key, value] of Object.entries(source)) {
+      if (!CONTROLLED_AUTH_HEADERS.has(key.toLowerCase())) {
+        headers[key] = value;
+      }
+    }
+
+    return headers;
+  }, {});
+}
+
+function authHeaders(
+  config: AuthClientConfig,
+  options: AuthRequestOptions = {},
+  extraHeaders: AuthHeaders = {}
+): AuthHeaders {
+  const tenantSlug = requireValue(
+    options.tenantSlug ?? config.tenantSlug,
+    "Tenant slug is required"
+  );
+
+  const upstreamJwt = requireValue(
+    options.upstreamJwt ?? config.upstreamJwt,
+    "Upstream JWT is required"
+  );
+
+  return {
+    ...customHeaders(config.headers, options.headers),
+    Authorization: bearer(upstreamJwt),
+    "X-Bold-Tenant-Slug": tenantSlug,
+    ...extraHeaders,
+  };
+}
+
+async function get<T>(
+  client: AxiosInstance,
+  config: AuthClientConfig,
+  url: string,
+  options?: AuthRequestOptions
+): Promise<T> {
+  try {
+    const res = await client.get(url, { headers: authHeaders(config, options) });
+    return camelizeKeys(res.data) as T;
+  } catch (error) {
+    throw new AuthAPIError("GET", url, error);
+  }
+}
+
+async function post<T>(
+  client: AxiosInstance,
+  config: AuthClientConfig,
+  url: string,
+  data?: Record<string, unknown>,
+  options?: AuthRequestOptions,
+  extraHeaders?: AuthHeaders
+): Promise<T> {
+  try {
+    const res = await client.post(url, data, {
+      headers: authHeaders(config, options, extraHeaders),
+    });
+    return camelizeKeys(res.data) as T;
+  } catch (error) {
+    throw new AuthAPIError("POST", url, error);
+  }
+}
+
+export function createAuthClient(options: AuthClientOptions) {
+  const tenantSlug = requireValue(options.tenantSlug, "Tenant slug is required");
+  const client = axios.create({
+    baseURL: options.baseURL ?? DEFAULT_API_BASE_URL,
+  });
+
+  const config: AuthClientConfig = {
+    tenantSlug,
+    upstreamJwt: options.upstreamJwt,
+    headers: options.headers ?? {},
+  };
+
+  return {
+    sessions: {
+      create: (data: AuthSessionCreateData, requestOptions?: AuthRequestOptions) => {
+        if (!data?.deviceId) throw new Error("Device ID is required");
+        if (!data?.platform) throw new Error("Platform is required");
+
+        return post<AuthSessionCreateResponse>(
+          client,
+          config,
+          "auth/sessions",
+          {
+            device_id: data.deviceId,
+            platform: data.platform,
+            user_agent: data.userAgent,
+          },
+          requestOptions
+        );
+      },
+      list: (requestOptions?: AuthRequestOptions) => {
+        return get<AuthSessionListResponse>(client, config, "auth/sessions", requestOptions);
+      },
+      verify: (sessionId: string, requestOptions?: AuthRequestOptions) => {
+        if (!sessionId) throw new Error("Session ID is required");
+        return get<AuthSessionVerifyResponse>(
+          client,
+          config,
+          `auth/sessions/${encodeURIComponent(sessionId)}/verify`,
+          requestOptions
+        );
+      },
+      revoke: (sessionId: string, requestOptions?: AuthRequestOptions) => {
+        if (!sessionId) throw new Error("Session ID is required");
+        return post<AuthSessionRevokeResponse>(
+          client,
+          config,
+          `auth/sessions/${encodeURIComponent(sessionId)}/revoke`,
+          undefined,
+          requestOptions
+        );
+      },
+      revokeOthers: (currentSessionId: string, requestOptions?: AuthRequestOptions) => {
+        if (!currentSessionId) throw new Error("Current session ID is required");
+        return post<AuthSessionRevokeOthersResponse>(
+          client,
+          config,
+          "auth/sessions/revoke-others",
+          undefined,
+          requestOptions,
+          { "X-Bold-Session-Id": currentSessionId }
+        );
+      },
+    },
+    challenges: {
+      verify: (challengeId: string, code: string, requestOptions?: AuthRequestOptions) => {
+        if (!challengeId) throw new Error("Challenge ID is required");
+        if (!code) throw new Error("Challenge code is required");
+
+        return post<AuthSessionCreateResponse>(
+          client,
+          config,
+          `auth/challenges/${encodeURIComponent(challengeId)}/verify`,
+          { code },
+          requestOptions
+        );
+      },
+      resend: (challengeId: string, requestOptions?: AuthRequestOptions) => {
+        if (!challengeId) throw new Error("Challenge ID is required");
+        return post<AuthChallengeResendResponse>(
+          client,
+          config,
+          `auth/challenges/${encodeURIComponent(challengeId)}/resend`,
+          undefined,
+          requestOptions
+        );
+      },
+    },
+  };
+}

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -6,6 +6,7 @@ import { listPosts, getPost, createPost, updatePost, deletePost, reactToPost, cr
 import { trackEvent, trackPageView } from './tracking'
 import { createAI } from './ai'
 import { DEFAULT_API_BASE_URL } from './constants'
+import { createSessionManagement } from './session-management'
 
 export type ClientOptions = {
   baseURL?: string
@@ -66,6 +67,7 @@ function createClient(apiKey: string, options: ClientOptions = {}) {
       getProgress: fetchProgress(apiClient),
       saveProgress: saveProgress(apiClient),
     },
+    sessionManagement: createSessionManagement(apiClient),
     ai: createAI(aiConfig),
     community: {
       posts: {

--- a/src/lib/session-management.ts
+++ b/src/lib/session-management.ts
@@ -1,0 +1,107 @@
+import { AxiosError, AxiosInstance } from "axios";
+
+import { camelizeKeys } from "../util/camelize";
+import type {
+  SessionManagementRevokeAllResponse,
+  SessionManagementRevokeSessionResponse,
+  SessionManagementViewerResolveResponse,
+  SessionManagementViewerSessionsResponse,
+} from "./types";
+
+type ApiClient = AxiosInstance;
+
+export class SessionManagementAPIError extends Error {
+  readonly status?: number;
+  readonly originalError?: Error;
+
+  constructor(method: string, url: string, error: unknown) {
+    if (error instanceof AxiosError) {
+      const status = error.response?.status;
+      const message =
+        error.response?.data?.error ||
+        error.response?.data?.message ||
+        error.response?.data?.code ||
+        error.message;
+      super(`${method} ${url} failed (${status}): ${message}`);
+      this.status = status;
+      this.originalError = error;
+    } else if (error instanceof Error) {
+      super(`${method} ${url} failed: ${error.message}`);
+      this.originalError = error;
+    } else {
+      super(`${method} ${url} failed: ${String(error)}`);
+    }
+    this.name = "SessionManagementAPIError";
+  }
+}
+
+export type SessionManagementRevokeOptions = {
+  reason?: string;
+};
+
+function byExternalIdPath(externalId: string): string {
+  if (!externalId) throw new Error("External ID is required");
+  return `session-management/viewers/by-external-id/${encodeURIComponent(externalId)}`;
+}
+
+async function get<T>(client: ApiClient, url: string): Promise<T> {
+  try {
+    const res = await client.get(url);
+    return camelizeKeys(res.data) as T;
+  } catch (error) {
+    throw new SessionManagementAPIError("GET", url, error);
+  }
+}
+
+async function post<T>(
+  client: ApiClient,
+  url: string,
+  data?: Record<string, unknown>
+): Promise<T> {
+  try {
+    const res = await client.post(url, data);
+    return camelizeKeys(res.data) as T;
+  } catch (error) {
+    throw new SessionManagementAPIError("POST", url, error);
+  }
+}
+
+export function createSessionManagement(client: ApiClient) {
+  return {
+    resolveViewerByExternalId: (externalId: string) => {
+      return get<SessionManagementViewerResolveResponse>(
+        client,
+        byExternalIdPath(externalId)
+      );
+    },
+    listViewerSessionsByExternalId: (externalId: string) => {
+      return get<SessionManagementViewerSessionsResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/sessions`
+      );
+    },
+    revokeViewerSessionByExternalId: (
+      externalId: string,
+      sessionId: string,
+      options: SessionManagementRevokeOptions = {}
+    ) => {
+      if (!sessionId) throw new Error("Session ID is required");
+
+      return post<SessionManagementRevokeSessionResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/sessions/${encodeURIComponent(sessionId)}/revoke`,
+        { reason: options.reason }
+      );
+    },
+    revokeAllViewerSessionsByExternalId: (
+      externalId: string,
+      options: SessionManagementRevokeOptions = {}
+    ) => {
+      return post<SessionManagementRevokeAllResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/sessions/revoke-all`,
+        { reason: options.reason }
+      );
+    },
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -572,6 +572,116 @@ export type ProgressListMeta = {
 };
 
 // ============================================
+// Session Management API Types
+// ============================================
+
+export type AuthSessionPlatform = "web" | "ios" | "android";
+
+export type AuthSessionCreateData = {
+  /** Stable browser/native device identifier from your app */
+  deviceId: string;
+  platform: AuthSessionPlatform;
+  userAgent?: string;
+};
+
+export type AuthActiveSession = {
+  id: string;
+  deviceId: string;
+  deviceLabel?: string | null;
+  platform: AuthSessionPlatform | string;
+  lastSeenAt: string;
+  insertedAt: string;
+};
+
+export type AuthSessionCreatedResponse = {
+  sessionId: string;
+  expiresAt: string;
+  bypassed?: never;
+  challengeRequired?: never;
+};
+
+export type AuthSessionBypassedResponse = {
+  sessionId: null;
+  bypassed: true;
+  expiresAt?: never;
+  challengeRequired?: never;
+};
+
+export type AuthSessionChallengeResponse = {
+  challengeRequired: true;
+  challengeId: string;
+  emailHint: string | null;
+  sessionId?: never;
+};
+
+export type AuthSessionCreateResponse =
+  | AuthSessionCreatedResponse
+  | AuthSessionBypassedResponse
+  | AuthSessionChallengeResponse;
+
+export type AuthSessionListResponse = {
+  data: AuthActiveSession[];
+};
+
+export type AuthSessionVerifyResponse =
+  | { valid: true; reason?: never }
+  | {
+      valid: false;
+      reason: "session_not_found" | "session_revoked" | "session_expired" | string;
+    };
+
+export type AuthSessionRevokeResponse = {
+  ok: boolean;
+  sessionId: string;
+};
+
+export type AuthSessionRevokeOthersResponse = {
+  ok: boolean;
+  revokedCount: number;
+};
+
+export type AuthChallengeResendResponse = {
+  ok: boolean;
+  challengeId: string;
+  emailHint: string | null;
+  resendCount: number;
+  expiresAt: string;
+};
+
+export type SessionManagementViewerResolveResponse = {
+  data: {
+    viewerId: string;
+    externalId: string;
+  };
+};
+
+export type SessionManagementSession = {
+  id: string;
+  deviceId: string;
+  deviceLabel?: string | null;
+  platform: AuthSessionPlatform | string;
+  lastSeenAt: string;
+  insertedAt: string;
+  revokedAt?: string | null;
+  revokedBy?: string | null;
+  revokedReason?: string | null;
+};
+
+export type SessionManagementViewerSessionsResponse = {
+  data: SessionManagementSession[];
+};
+
+export type SessionManagementRevokeSessionResponse = {
+  ok: boolean;
+  sessionId: string;
+};
+
+export type SessionManagementRevokeAllResponse = {
+  ok: boolean;
+  revokedCount: number;
+};
+
+// ============================================
 // Video List Options
 // ============================================
 


### PR DESCRIPTION
## Summary

`bold-js` now includes typed helpers for Bold session management. Browser integrations can create, list, verify, and revoke viewer sessions with an upstream JWT, while server integrations can look up viewers by external ID and manage their connected sessions through the authenticated Bold API client.

## Release

- Adds a Changesets minor bump for `@boldvideo/bold-js`.
- Leaves `package.json` version unchanged in this feature PR; the existing Changesets workflow will create the release PR after merge.
- The release workflow builds the package before publishing and uses npm provenance.
- Tightens npm packaging so the published tarball includes only package metadata, README/CHANGELOG/llms docs, and generated `dist` files.

## Testing

- `pnpm run lint`
- `pnpm run build`
- `pnpm exec changeset status --since=origin/main` reports a minor bump for `@boldvideo/bold-js`.
- `npm pack --dry-run --json` confirms the package includes the intended generated entrypoints, type declarations, and public docs.

## Notes

The package currently relies on TypeScript compilation, bundle build, and package import checks in CI rather than dedicated SDK method-level tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784791766&installation_id=135138357&pr_number=60&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F60&signature=35448e2b6168f764cd20ca7c79b9e3681f7f64aaab6cbc4d2645498506815341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
