### PR TITLE
feat: add server-side session management admin helpers

### DIFF
--- a/.changeset/bold-session-admin-controls.md
+++ b/.changeset/bold-session-admin-controls.md
@@ -1,0 +1,5 @@
+---
+"@boldvideo/bold-js": minor
+---
+
+Add server-side session-management helpers for viewer state, device-limit overrides, and viewer exemptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This is the Bold JavaScript SDK (`@boldvideo/bold-js`) - a TypeScript client lib
 pnpm install          # Install dependencies
 pnpm run build        # Build to dist/ (ESM + CJS + type declarations)
 pnpm run lint         # Type checking with tsc
+pnpm test             # Build and run Node test-runner smoke tests
 pnpm changeset        # Create a changeset for versioning
 ```
 
@@ -123,8 +124,9 @@ bold.trackPageView()      // Track page views
 ## Testing
 
 - Run `pnpm run lint` before committing
+- Run `pnpm test` when changing runtime SDK methods
 - Ensure TypeScript compilation succeeds with no errors
-- No test framework currently configured - manual testing required
+- Runtime smoke tests use Node's built-in test runner under `test/`
 
 ## Boundaries
 
@@ -144,4 +146,4 @@ bold.trackPageView()      // Track page views
 **Never:**
 - Commit API keys or secrets
 - Remove or change existing public type exports without versioning
-- Add test files without setting up a test framework first
+- Add test files without wiring them into `pnpm test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ pnpm run build
 # Run type checking/linting
 pnpm run lint
 
+# Build and run Node test-runner smoke tests
+pnpm test
+
 # Create a changeset (for versioning)
 pnpm changeset
 ```
@@ -77,6 +80,7 @@ The SDK uses a factory pattern where `createClient(apiKey)` returns an object wi
 2. When making changes:
    - Ensure TypeScript types are properly defined
    - Run `pnpm run lint` before committing
+   - Run `pnpm test` when changing runtime SDK methods
    - The SDK supports both ESM and CommonJS consumers
 
 3. API Integration:
@@ -91,7 +95,7 @@ The SDK uses a factory pattern where `createClient(apiKey)` returns an object wi
 
 ## Important Notes
 
-- No test framework is currently configured
+- Runtime smoke tests use Node's built-in test runner under `/test`
 - The SDK is designed to be lightweight with minimal dependencies (only axios)
 - All API responses follow the type definitions in `/src/lib/types.ts`
 - The tracking system includes automatic throttling to handle high-frequency events like video progress updates

--- a/README.md
+++ b/README.md
@@ -243,14 +243,38 @@ await auth.sessions.revokeOthers(currentSessionId);
 
 ### Server-Side Session Management
 
-Customer servers can inspect and revoke BOLD device sessions by upstream
-external ID using the normal BOLD tenant API key. Keep this API key server-side.
-Do not put a BOLD tenant key or admin key in browser code.
+Customer servers can inspect BOLD device state, revoke sessions, and manage
+per-viewer device-limit overrides or exemptions by upstream external ID using
+the normal BOLD tenant API key. Keep this API key server-side. Do not put a
+BOLD tenant key or admin key in browser code.
 
 ```typescript
 import { createClient } from '@boldvideo/bold-js';
 
 const bold = createClient(process.env.BOLD_TENANT_API_KEY!);
+
+const { data: state } =
+  await bold.sessionManagement.getViewerSessionManagementStateByExternalId(
+    outsetaPersonUid
+  );
+
+if (state.canUpdateDeviceLimitOverride) {
+  await bold.sessionManagement.setViewerDeviceLimitOverrideByExternalId(
+    outsetaPersonUid,
+    5
+  );
+
+  await bold.sessionManagement.clearViewerDeviceLimitOverrideByExternalId(
+    outsetaPersonUid
+  );
+}
+
+if (state.canUpdateSessionManagementExemption) {
+  await bold.sessionManagement.setViewerSessionManagementExemptionByExternalId(
+    outsetaPersonUid,
+    true
+  );
+}
 
 const { data: sessions } =
   await bold.sessionManagement.listViewerSessionsByExternalId(outsetaPersonUid);
@@ -261,8 +285,12 @@ await bold.sessionManagement.revokeAllViewerSessionsByExternalId(
 );
 ```
 
-The server-side session-management methods cannot update policy, JWT config,
-feature flags, viewer device-limit overrides, or exemptions.
+`setViewerDeviceLimitOverrideByExternalId` requires a positive safe integer.
+Use `clearViewerDeviceLimitOverrideByExternalId` for explicit clearing.
+
+The server-side session-management methods cannot update JWT config, account
+feature flags, session TTL, or email template setup. Those remain BOLD operator
+controls.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -159,8 +159,35 @@ const bold = createClient(process.env.BOLD_TENANT_API_KEY!);
 const { data: viewer } =
   await bold.sessionManagement.resolveViewerByExternalId(outsetaPersonUid);
 
+const { data: state } =
+  await bold.sessionManagement.getViewerSessionManagementStateByExternalId(
+    outsetaPersonUid
+  );
+
 const { data: sessions } =
   await bold.sessionManagement.listViewerSessionsByExternalId(outsetaPersonUid);
+
+if (state.canUpdateDeviceLimitOverride) {
+  await bold.sessionManagement.setViewerDeviceLimitOverrideByExternalId(
+    outsetaPersonUid,
+    5
+  );
+
+  await bold.sessionManagement.clearViewerDeviceLimitOverrideByExternalId(
+    outsetaPersonUid
+  );
+}
+
+if (state.canUpdateSessionManagementExemption) {
+  await bold.sessionManagement.setViewerSessionManagementExemptionByExternalId(
+    outsetaPersonUid,
+    true
+  );
+
+  await bold.sessionManagement.clearViewerSessionManagementExemptionByExternalId(
+    outsetaPersonUid
+  );
+}
 
 await bold.sessionManagement.revokeViewerSessionByExternalId(
   outsetaPersonUid,
@@ -175,8 +202,11 @@ await bold.sessionManagement.revokeAllViewerSessionsByExternalId(
 ```
 
 Server-side session-management methods can inspect and revoke sessions by
-upstream external ID. They cannot update policy, JWT config, feature flags,
-viewer device-limit overrides, or exemptions.
+upstream external ID, and can manage per-viewer device-limit overrides and
+session-management exemptions when the returned `canUpdate*` flags allow it.
+`setViewerDeviceLimitOverrideByExternalId` requires a positive safe integer; use
+the clear helper for explicit clearing. These methods cannot update policy, JWT
+config, feature flags, session TTLs, or BOLD operator provisioning.
 
 ## Community API
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --target es2020",
-    "lint": "tsc"
+    "lint": "tsc",
+    "test": "pnpm build && node --test test/*.test.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,8 @@ export type {
   AuthSessionRevokeResponse,
   AuthSessionRevokeOthersResponse,
   AuthChallengeResendResponse,
+  SessionManagementViewerState,
+  SessionManagementViewerStateResponse,
   SessionManagementViewerResolveResponse,
   SessionManagementSession,
   SessionManagementViewerSessionsResponse,

--- a/src/lib/session-management.ts
+++ b/src/lib/session-management.ts
@@ -4,6 +4,7 @@ import { camelizeKeys } from "../util/camelize";
 import type {
   SessionManagementRevokeAllResponse,
   SessionManagementRevokeSessionResponse,
+  SessionManagementViewerStateResponse,
   SessionManagementViewerResolveResponse,
   SessionManagementViewerSessionsResponse,
 } from "./types";
@@ -44,6 +45,12 @@ function byExternalIdPath(externalId: string): string {
   return `session-management/viewers/by-external-id/${encodeURIComponent(externalId)}`;
 }
 
+function assertDeviceLimitOverride(limit: number): void {
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new Error("Device-limit override must be a positive safe integer");
+  }
+}
+
 async function get<T>(client: ApiClient, url: string): Promise<T> {
   try {
     const res = await client.get(url);
@@ -66,6 +73,19 @@ async function post<T>(
   }
 }
 
+async function put<T>(
+  client: ApiClient,
+  url: string,
+  data?: Record<string, unknown>
+): Promise<T> {
+  try {
+    const res = await client.put(url, data);
+    return camelizeKeys(res.data) as T;
+  } catch (error) {
+    throw new SessionManagementAPIError("PUT", url, error);
+  }
+}
+
 export function createSessionManagement(client: ApiClient) {
   return {
     resolveViewerByExternalId: (externalId: string) => {
@@ -74,10 +94,52 @@ export function createSessionManagement(client: ApiClient) {
         byExternalIdPath(externalId)
       );
     },
+    getViewerSessionManagementStateByExternalId: (externalId: string) => {
+      return get<SessionManagementViewerStateResponse>(
+        client,
+        byExternalIdPath(externalId)
+      );
+    },
     listViewerSessionsByExternalId: (externalId: string) => {
       return get<SessionManagementViewerSessionsResponse>(
         client,
         `${byExternalIdPath(externalId)}/sessions`
+      );
+    },
+    setViewerDeviceLimitOverrideByExternalId: (
+      externalId: string,
+      limit: number
+    ) => {
+      assertDeviceLimitOverride(limit);
+
+      return put<SessionManagementViewerStateResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/device-limit`,
+        { limit }
+      );
+    },
+    clearViewerDeviceLimitOverrideByExternalId: (externalId: string) => {
+      return put<SessionManagementViewerStateResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/device-limit`,
+        { limit: null }
+      );
+    },
+    setViewerSessionManagementExemptionByExternalId: (
+      externalId: string,
+      exempt: boolean
+    ) => {
+      return put<SessionManagementViewerStateResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/session-management-exemption`,
+        { exempt }
+      );
+    },
+    clearViewerSessionManagementExemptionByExternalId: (externalId: string) => {
+      return put<SessionManagementViewerStateResponse>(
+        client,
+        `${byExternalIdPath(externalId)}/session-management-exemption`,
+        { exempt: false }
       );
     },
     revokeViewerSessionByExternalId: (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -648,11 +648,29 @@ export type AuthChallengeResendResponse = {
   expiresAt: string;
 };
 
-export type SessionManagementViewerResolveResponse = {
-  data: {
-    viewerId: string;
-    externalId: string;
-  };
+export type SessionManagementViewerState = {
+  viewerId: string;
+  externalId: string;
+  activeSessionCount: number;
+  policyDefaultDeviceLimit: number;
+  effectiveDeviceLimit: number | null;
+  effectiveDeviceLimitSource: "policy" | "override" | "exempt";
+  deviceLimitOverride: number | null;
+  sessionManagementExempt: boolean;
+  adminOverridesAllowed: boolean;
+  canUpdateDeviceLimitOverride: boolean;
+  canUpdateSessionManagementExemption: boolean;
+};
+
+export type SessionManagementViewerStateResponse = {
+  data: SessionManagementViewerState;
+};
+
+export type SessionManagementViewerResolveResponse = SessionManagementViewerStateResponse;
+
+export type SessionManagementViewerSessionsResponse = {
+  viewer: SessionManagementViewerState;
+  data: SessionManagementSession[];
 };
 
 export type SessionManagementSession = {
@@ -665,10 +683,6 @@ export type SessionManagementSession = {
   revokedAt?: string | null;
   revokedBy?: string | null;
   revokedReason?: string | null;
-};
-
-export type SessionManagementViewerSessionsResponse = {
-  data: SessionManagementSession[];
 };
 
 export type SessionManagementRevokeSessionResponse = {

--- a/test/session-management.test.mjs
+++ b/test/session-management.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test, { after, before, beforeEach } from "node:test";
+
+import { createClient, SessionManagementAPIError } from "../dist/index.js";
+
+const requests = [];
+
+let server;
+let baseURL;
+
+before(async () => {
+  server = createServer(async (req, res) => {
+    const chunks = [];
+
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+    const body = rawBody ? JSON.parse(rawBody) : null;
+
+    requests.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      body,
+    });
+
+    if (decodeURIComponent(req.url).includes("/blocked/")) {
+      res.writeHead(403, { "content-type": "application/json" });
+      res.end(JSON.stringify({ code: "admin_overrides_disabled" }));
+      return;
+    }
+
+    res.writeHead(200, { "content-type": "application/json" });
+
+    if (req.url.endsWith("/sessions")) {
+      res.end(
+        JSON.stringify({
+          viewer: viewerState(),
+          data: [
+            {
+              id: "session-1",
+              device_id: "device-1",
+              device_label: "Laptop",
+              platform: "web",
+              last_seen_at: "2026-06-23T10:00:00Z",
+              inserted_at: "2026-06-23T09:00:00Z",
+              revoked_at: null,
+              revoked_by: null,
+              revoked_reason: null,
+            },
+          ],
+        })
+      );
+      return;
+    }
+
+    res.end(JSON.stringify({ data: viewerState() }));
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const { port } = server.address();
+  baseURL = `http://127.0.0.1:${port}/api/v1/`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+});
+
+beforeEach(() => {
+  requests.length = 0;
+});
+
+test("sets and clears viewer device-limit overrides by external ID", async () => {
+  const sessionManagement = createSessionManagementClient();
+
+  const setResponse =
+    await sessionManagement.setViewerDeviceLimitOverrideByExternalId(
+      "outseta:p/one",
+      7
+    );
+
+  assert.equal(requests[0].method, "PUT");
+  assert.equal(
+    requests[0].url,
+    "/api/v1/session-management/viewers/by-external-id/outseta%3Ap%2Fone/device-limit"
+  );
+  assert.deepEqual(requests[0].body, { limit: 7 });
+  assert.equal(requests[0].authorization, "tenant-key");
+  assert.equal(setResponse.data.viewerId, "viewer-1");
+  assert.equal(setResponse.data.activeSessionCount, 2);
+  assert.equal(setResponse.data.effectiveDeviceLimitSource, "override");
+  assert.equal(setResponse.data.canUpdateDeviceLimitOverride, true);
+  assert.equal(setResponse.data.canUpdateSessionManagementExemption, true);
+
+  await sessionManagement.clearViewerDeviceLimitOverrideByExternalId("outseta:p/one");
+
+  assert.equal(requests[1].method, "PUT");
+  assert.deepEqual(requests[1].body, { limit: null });
+});
+
+test("rejects invalid device-limit override numbers before sending a request", async () => {
+  const sessionManagement = createSessionManagementClient();
+
+  for (const limit of [Number.NaN, Infinity, -Infinity, 0, 1.5]) {
+    assert.throws(
+      () =>
+        sessionManagement.setViewerDeviceLimitOverrideByExternalId(
+          "outseta:p/one",
+          limit
+        ),
+      /positive safe integer/
+    );
+  }
+
+  assert.equal(requests.length, 0);
+});
+
+test("sets and clears viewer session-management exemptions by external ID", async () => {
+  const sessionManagement = createSessionManagementClient();
+
+  await sessionManagement.setViewerSessionManagementExemptionByExternalId(
+    "outseta:p/one",
+    true
+  );
+
+  assert.equal(requests[0].method, "PUT");
+  assert.equal(
+    requests[0].url,
+    "/api/v1/session-management/viewers/by-external-id/outseta%3Ap%2Fone/session-management-exemption"
+  );
+  assert.deepEqual(requests[0].body, { exempt: true });
+
+  await sessionManagement.clearViewerSessionManagementExemptionByExternalId(
+    "outseta:p/one"
+  );
+
+  assert.deepEqual(requests[1].body, { exempt: false });
+});
+
+test("camelizes viewer state on session-list responses", async () => {
+  const response =
+    await createSessionManagementClient().listViewerSessionsByExternalId(
+      "outseta:p/one"
+    );
+
+  assert.equal(response.viewer.viewerId, "viewer-1");
+  assert.equal(response.viewer.deviceLimitOverride, 5);
+  assert.equal(response.data[0].deviceId, "device-1");
+  assert.equal(response.data[0].revokedAt, null);
+});
+
+test("wraps failed PUT requests with status and server error code", async () => {
+  await assert.rejects(
+    createSessionManagementClient().setViewerDeviceLimitOverrideByExternalId(
+      "blocked/user",
+      4
+    ),
+    (error) => {
+      assert.ok(error instanceof SessionManagementAPIError);
+      assert.equal(error.status, 403);
+      assert.match(error.message, /admin_overrides_disabled/);
+      return true;
+    }
+  );
+});
+
+function createSessionManagementClient() {
+  return createClient("tenant-key", { baseURL }).sessionManagement;
+}
+
+function viewerState() {
+  return {
+    viewer_id: "viewer-1",
+    external_id: "outseta:p/one",
+    active_session_count: 2,
+    policy_default_device_limit: 3,
+    effective_device_limit: 5,
+    effective_device_limit_source: "override",
+    device_limit_override: 5,
+    session_management_exempt: false,
+    admin_overrides_allowed: true,
+    can_update_device_limit_override: true,
+    can_update_session_management_exemption: true,
+  };
+}


### PR DESCRIPTION
## Summary

Server-side integrations can now manage viewer session controls through typed session-management helpers instead of assembling endpoint paths manually.

The helpers expose viewer state, connected-session responses with viewer metadata, device-limit override updates, and exemption updates. Numeric override validation happens before a request is sent, and explicit clear helpers keep "clear" separate from invalid values.

## Validation

- `pnpm lint`
- `pnpm test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784804575&installation_id=135138357&pr_number=61&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F61&signature=022401aab6841ae9396551b8df23b3850c2a3cd991277bc2573e9f1c0a7ac7ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->