### PR TITLE
feat: forward client_ip on auth.sessions.create

### DIFF
--- a/.changeset/forward-client-ip-on-session-create.md
+++ b/.changeset/forward-client-ip-on-session-create.md
@@ -1,0 +1,5 @@
+---
+"@boldvideo/bold-js": minor
+---
+
+Forward `clientIp` on `auth.sessions.create`. The new optional `clientIp` field on `AuthSessionCreateData` is sent as `client_ip` in the POST body so server-authoritative integrators can attribute a session to the end-user IP for coarse geo resolution. When omitted, the field is not sent and the backend falls back to the proxy-aware transport IP.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -168,6 +168,7 @@ export function createAuthClient(options: AuthClientOptions) {
             device_id: data.deviceId,
             platform: data.platform,
             user_agent: data.userAgent,
+            client_ip: data.clientIp,
           },
           requestOptions
         );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -582,6 +582,15 @@ export type AuthSessionCreateData = {
   deviceId: string;
   platform: AuthSessionPlatform;
   userAgent?: string;
+  /**
+   * End-user IP address to attribute the session to, for coarse geo
+   * resolution (`location`/region on session objects). Same trust model as
+   * `userAgent`: caller-supplied. Server-authoritative integrators should set
+   * this to the viewer's IP (e.g. the leftmost `x-forwarded-for` entry), since
+   * the transport IP Bold sees is the datacenter egress. When omitted, the
+   * backend falls back to the proxy-aware transport IP.
+   */
+  clientIp?: string;
 };
 
 export type AuthActiveSession = {

--- a/test/auth-sessions.test.mjs
+++ b/test/auth-sessions.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test, { after, before, beforeEach } from "node:test";
+
+import { createAuthClient } from "../dist/index.js";
+
+const requests = [];
+
+let server;
+let baseURL;
+
+before(async () => {
+  server = createServer(async (req, res) => {
+    const chunks = [];
+
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+    const body = rawBody ? JSON.parse(rawBody) : null;
+
+    requests.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      tenantSlug: req.headers["x-bold-tenant-slug"],
+      body,
+    });
+
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        session_id: "session-1",
+        expires_at: "2026-06-24T12:00:00Z",
+      })
+    );
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const { port } = server.address();
+  baseURL = `http://127.0.0.1:${port}/api/v1/`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+});
+
+beforeEach(() => {
+  requests.length = 0;
+});
+
+test("forwards client_ip in the create body when provided", async () => {
+  const auth = createAuthClient({
+    baseURL,
+    tenantSlug: "acme",
+    upstreamJwt: "jwt-123",
+  });
+
+  const response = await auth.sessions.create({
+    deviceId: "device-1",
+    platform: "web",
+    userAgent: "Mozilla/5.0",
+    clientIp: "203.0.113.7",
+  });
+
+  assert.equal(requests[0].method, "POST");
+  assert.equal(requests[0].url, "/api/v1/auth/sessions");
+  assert.deepEqual(requests[0].body, {
+    device_id: "device-1",
+    platform: "web",
+    user_agent: "Mozilla/5.0",
+    client_ip: "203.0.113.7",
+  });
+  assert.equal(requests[0].authorization, "Bearer jwt-123");
+  assert.equal(requests[0].tenantSlug, "acme");
+  assert.equal(response.sessionId, "session-1");
+});
+
+test("omits client_ip from the create body when not provided", async () => {
+  const auth = createAuthClient({
+    baseURL,
+    tenantSlug: "acme",
+    upstreamJwt: "jwt-123",
+  });
+
+  await auth.sessions.create({
+    deviceId: "device-1",
+    platform: "web",
+    userAgent: "Mozilla/5.0",
+  });
+
+  assert.deepEqual(requests[0].body, {
+    device_id: "device-1",
+    platform: "web",
+    user_agent: "Mozilla/5.0",
+  });
+  assert.ok(!("client_ip" in requests[0].body));
+});


### PR DESCRIPTION
## Summary

`auth.sessions.create` built the `POST /auth/sessions` body as an explicit field map (`device_id`, `platform`, `user_agent`) with no spread, so any additional field was dropped before the request was sent. This adds an optional `clientIp` to `AuthSessionCreateData` and forwards it as `client_ip`, mirroring how `userAgent` → `user_agent` already works.

### Why

Server-authoritative integrators create sessions server-side, so the transport IP the API sees is the datacenter egress rather than the viewer — coarse geo resolution attributes the session to the datacenter. Passing the end-user IP explicitly lets the backend attribute the session to the viewer. When `clientIp` is omitted, the backend falls back to the proxy-aware transport IP.

## Changes

- **`src/lib/types.ts`** — add optional `clientIp?: string` to `AuthSessionCreateData`, with a doc comment.
- **`src/lib/auth.ts`** — add `client_ip: data.clientIp` to the `sessions.create` body. When `clientIp` is `undefined`, JSON serialization drops the key, so nothing is sent on the wire.
- **`test/auth-sessions.test.mjs`** — new test file (local HTTP server against the built `dist/`): asserts `client_ip` is present when provided and absent when omitted, plus auth header/tenant wiring.
- **`.changeset/`** — minor bump for `@boldvideo/bold-js` (additive, backward-compatible field).

## Testing

- `pnpm run lint` (tsc strict) — clean.
- `pnpm test` (build + `node --test`) — all pass, including the 2 new `client_ip` cases.
- `pnpm exec changeset status` — reports a minor bump.

## Release

Adds a Changesets minor bump only; `package.json` version is unchanged in this feature PR. The existing Changesets workflow opens the release PR after merge, and merging that publishes to npm.
