### PR TITLE
feat: expose travelVerdict on viewer-session items

### DIFF
--- a/.changeset/viewer-session-travel-verdict.md
+++ b/.changeset/viewer-session-travel-verdict.md
@@ -1,0 +1,5 @@
+---
+"@boldvideo/bold-js": minor
+---
+
+Expose `travelVerdict` on viewer-session items. The session-management viewer-sessions methods (e.g. `listViewerSessionsByExternalId`) now return `travelVerdict: "impossible_travel" | null` on each session, surfacing Bold's authoritative impossible-travel signal. The new `TravelVerdict` type is exported. It is a label only — no coordinates, IP, distance, or speed — and defaults to `null` when a session is unflagged or the backend predates the field.

--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ if (state.canUpdateSessionManagementExemption) {
 const { data: sessions } =
   await bold.sessionManagement.listViewerSessionsByExternalId(outsetaPersonUid);
 
+for (const session of sessions) {
+  if (session.travelVerdict === 'impossible_travel') {
+    // Bold flagged this sign-in as physically implausible.
+  }
+}
+
 await bold.sessionManagement.revokeAllViewerSessionsByExternalId(
   outsetaPersonUid,
   { reason: 'outseta:membership_changed' }
@@ -287,6 +293,12 @@ await bold.sessionManagement.revokeAllViewerSessionsByExternalId(
 
 `setViewerDeviceLimitOverrideByExternalId` requires a positive safe integer.
 Use `clearViewerDeviceLimitOverrideByExternalId` for explicit clearing.
+
+Each session item carries `travelVerdict: 'impossible_travel' | null` — Bold's
+authoritative impossible-travel signal, exposed by these admin-scoped
+session-management methods. It is a **label only**: the SDK never returns
+coordinates, the raw IP, or derived distance/speed. It is `null` when the
+sign-in was not flagged (and for backends that predate the field).
 
 The server-side session-management methods cannot update JWT config, account
 feature flags, session TTL, or email template setup. Those remain BOLD operator

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export type {
   SessionManagementViewerStateResponse,
   SessionManagementViewerResolveResponse,
   SessionManagementSession,
+  TravelVerdict,
   SessionManagementViewerSessionsResponse,
   SessionManagementRevokeSessionResponse,
   SessionManagementRevokeAllResponse,

--- a/src/lib/session-management.ts
+++ b/src/lib/session-management.ts
@@ -51,6 +51,25 @@ function assertDeviceLimitOverride(limit: number): void {
   }
 }
 
+/**
+ * Normalize the impossible-travel verdict to a stable `null` default.
+ *
+ * Backends that predate the verdict field omit it entirely; coercing the
+ * missing value to `null` means consumers only ever switch on the label vs.
+ * `null` (never `undefined`).
+ */
+function normalizeViewerSessions(
+  response: SessionManagementViewerSessionsResponse
+): SessionManagementViewerSessionsResponse {
+  return {
+    ...response,
+    data: response.data.map((session) => ({
+      ...session,
+      travelVerdict: session.travelVerdict ?? null,
+    })),
+  };
+}
+
 async function get<T>(client: ApiClient, url: string): Promise<T> {
   try {
     const res = await client.get(url);
@@ -100,11 +119,12 @@ export function createSessionManagement(client: ApiClient) {
         byExternalIdPath(externalId)
       );
     },
-    listViewerSessionsByExternalId: (externalId: string) => {
-      return get<SessionManagementViewerSessionsResponse>(
+    listViewerSessionsByExternalId: async (externalId: string) => {
+      const response = await get<SessionManagementViewerSessionsResponse>(
         client,
         `${byExternalIdPath(externalId)}/sessions`
       );
+      return normalizeViewerSessions(response);
     },
     setViewerDeviceLimitOverrideByExternalId: (
       externalId: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -705,10 +705,14 @@ export type SessionManagementSession = {
   /**
    * Impossible-travel verdict label: `"impossible_travel"` when the sign-in
    * was flagged, otherwise `null`. Surfaced by the admin-scoped
-   * session-management viewer-sessions API. `null` when unflagged or when the
-   * backend predates this field.
+   * session-management viewer-sessions API.
+   *
+   * Optional on the type (consistent with the other nullable fields here, so
+   * the field stays additive), but SDK responses always populate it:
+   * `listViewerSessionsByExternalId` normalizes a missing value to `null`,
+   * whether the session is unflagged or the backend predates the field.
    */
-  travelVerdict: TravelVerdict | null;
+  travelVerdict?: TravelVerdict | null;
 };
 
 export type SessionManagementRevokeSessionResponse = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -682,6 +682,16 @@ export type SessionManagementViewerSessionsResponse = {
   data: SessionManagementSession[];
 };
 
+/**
+ * Bold's impossible-travel verdict for a session, exposed as a label only.
+ *
+ * `"impossible_travel"` means Bold flagged the sign-in as physically
+ * implausible (two sessions too far apart to travel between in the elapsed
+ * time). Label only — the SDK never exposes coordinates, the raw IP, or
+ * derived distance/speed metrics.
+ */
+export type TravelVerdict = "impossible_travel";
+
 export type SessionManagementSession = {
   id: string;
   deviceId: string;
@@ -692,6 +702,13 @@ export type SessionManagementSession = {
   revokedAt?: string | null;
   revokedBy?: string | null;
   revokedReason?: string | null;
+  /**
+   * Impossible-travel verdict label: `"impossible_travel"` when the sign-in
+   * was flagged, otherwise `null`. Surfaced by the admin-scoped
+   * session-management viewer-sessions API. `null` when unflagged or when the
+   * backend predates this field.
+   */
+  travelVerdict: TravelVerdict | null;
 };
 
 export type SessionManagementRevokeSessionResponse = {

--- a/test/session-management.test.mjs
+++ b/test/session-management.test.mjs
@@ -50,6 +50,31 @@ before(async () => {
               revoked_at: null,
               revoked_by: null,
               revoked_reason: null,
+              travel_verdict: "impossible_travel",
+            },
+            {
+              id: "session-2",
+              device_id: "device-2",
+              device_label: "Phone",
+              platform: "ios",
+              last_seen_at: "2026-06-23T10:05:00Z",
+              inserted_at: "2026-06-23T09:05:00Z",
+              revoked_at: null,
+              revoked_by: null,
+              revoked_reason: null,
+              travel_verdict: null,
+            },
+            {
+              // Older backend during rollout: omits travel_verdict entirely.
+              id: "session-3",
+              device_id: "device-3",
+              device_label: "Tablet",
+              platform: "android",
+              last_seen_at: "2026-06-23T10:10:00Z",
+              inserted_at: "2026-06-23T09:10:00Z",
+              revoked_at: null,
+              revoked_by: null,
+              revoked_reason: null,
             },
           ],
         })
@@ -158,6 +183,23 @@ test("camelizes viewer state on session-list responses", async () => {
   assert.equal(response.viewer.deviceLimitOverride, 5);
   assert.equal(response.data[0].deviceId, "device-1");
   assert.equal(response.data[0].revokedAt, null);
+});
+
+test("exposes the impossible-travel verdict label, defaulting absent to null", async () => {
+  const response =
+    await createSessionManagementClient().listViewerSessionsByExternalId(
+      "outseta:p/one"
+    );
+
+  const byId = Object.fromEntries(response.data.map((s) => [s.id, s]));
+
+  // Flagged session passes the label through.
+  assert.equal(byId["session-1"].travelVerdict, "impossible_travel");
+  // Unflagged session is an explicit null.
+  assert.equal(byId["session-2"].travelVerdict, null);
+  // Older backend omits the field → normalized to a stable null (not undefined).
+  assert.ok("travelVerdict" in byId["session-3"]);
+  assert.equal(byId["session-3"].travelVerdict, null);
 });
 
 test("wraps failed PUT requests with status and server error code", async () => {


### PR DESCRIPTION
## Summary

The session-management viewer-sessions methods now surface Bold's impossible-travel signal on each session item, so integrators can render it directly instead of re-deriving a weaker signal from coarse location.

- `SessionManagementSession` gains `travelVerdict: "impossible_travel" | null`.
- New `TravelVerdict` type is exported so consumers can switch on it.
- Returned by `sessionManagement.listViewerSessionsByExternalId` (and any current/future viewer-sessions method sharing the item type).

It's a **label only** — the SDK never reads or exposes coordinates, the raw IP, or derived distance/speed.

## Changes

- **`src/lib/types.ts`** — add the exported `TravelVerdict` type and the `travelVerdict` field on `SessionManagementSession`, with doc comments.
- **`src/lib/session-management.ts`** — `listViewerSessionsByExternalId` normalizes a missing `travelVerdict` to `null`. The deep camelize boundary already maps `travel_verdict` → `travelVerdict`; this guarantees one stable shape (`"impossible_travel" | null`, never `undefined`) even against an older API response.
- **`src/index.ts`** — export `TravelVerdict`.
- **`test/session-management.test.mjs`** — cover flagged → `"impossible_travel"`, unflagged → `null`, and field-absent → `null`.
- **`README.md`** — document the field as label-only and admin-client-scoped.
- **`.changeset/`** — minor bump.

## Backward compatibility

Additive and nullable. The field defaults to `null` for unflagged sessions and for any API response that predates it, so the SDK is safe to release independently of the backend rollout (it simply returns `null` until the field is live).

## Testing

- `pnpm run lint` (tsc strict) — clean.
- `pnpm test` (build + `node --test`) — 8/8 pass, including the new verdict cases.
- `pnpm exec changeset status` — reports a minor bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/bold-js/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785052535&installation_id=135138357&pr_number=66&repository=boldvideo%2Fbold-js&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fbold-js%2Fpull%2F66&signature=dbd2b735916db6eb86b1e71a37e20209f92fb6d61cb5fa6459366f01802d4bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewer session results now expose an optional, label-only `travelVerdict` indicating impossible travel (value: `impossible_travel`).
  * The SDK now exports a `TravelVerdict` type for easier typing.
* **Bug Fixes**
  * Session lists now consistently provide `travelVerdict: null` when no verdict is available, including when older backend responses omit the field.
* **Documentation**
  * Updated server-side session management examples to check `travelVerdict === 'impossible_travel'`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->